### PR TITLE
Add git setup helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# nueral-networks
+
+This repository includes example neural network scripts.
+
+## Git setup helper
+
+Run `setup_git.sh` in this directory to configure Git with your username, email, and remote. You'll still need to provide your GitHub username and personal access token the first time you push.
+

--- a/setup_git.sh
+++ b/setup_git.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Setup Git identity, credential helper, and remote.
+
+git config --global user.name "jimenezjaime02"
+git config --global user.email "jimenezjaime02@gmail.com"
+# Store credentials so you don't have to re-enter them after the first push
+# (you will still need to supply your GitHub username and personal access token once)
+git config --global credential.helper store
+
+# Set the remote named origin, replacing if it already exists
+if git remote | grep -q '^origin$'; then
+    git remote set-url origin https://github.com/jimenezjaime02/nueral-networks.git
+else
+    git remote add origin https://github.com/jimenezjaime02/nueral-networks.git
+fi
+
+echo "Git configuration complete. Remote 'origin' set to https://github.com/jimenezjaime02/nueral-networks.git"
+


### PR DESCRIPTION
## Summary
- add `setup_git.sh` to reconfigure Git credentials and remote
- document how to use the script in a new README

## Testing
- `./setup_git.sh`

------
https://chatgpt.com/codex/tasks/task_e_684307b8cf94832891ca1aa4bdd72654