### PR TITLE
Add environment script for script paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ This repository includes example neural network scripts.
 
 Run `setup_git.sh` in this directory to configure Git with your username, email, and remote. You'll still need to provide your GitHub username and personal access token the first time you push.
 
+## Environment variables
+
+Source `env_paths.sh` to populate environment variables for each example script.
+```bash
+source env_paths.sh
+```
+After sourcing, variables like `$CAT_DOG_CLASSIFIER2_PY` or `$VAE_PY` will hold the absolute path to the corresponding Python script. This lets you quickly run any script:
+
+```bash
+python "$VAE_PY"
+```
+

--- a/env_paths.sh
+++ b/env_paths.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Environment variables for neural network example scripts
+
+# Directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Python script paths
+export CAT_DOG_CLASSIFIER2_PY="$SCRIPT_DIR/cat_dog_classifier2.py"
+export DIFFUSION_PY="$SCRIPT_DIR/diffusion.py"
+export DIFFUSION2_PY="$SCRIPT_DIR/diffusion2.py"
+export DIFFUSION3_PY="$SCRIPT_DIR/diffusion3.py"
+export STYLE_TRANSFER_PY="$SCRIPT_DIR/style_transfer.py"
+export STYLE_TRANSFER2_PY="$SCRIPT_DIR/style_transfer2.py"
+export TRANSFORMER_PY="$SCRIPT_DIR/transformer.py"
+export VAE_PY="$SCRIPT_DIR/vae.py"
+
+# Usage message
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    echo "This script sets environment variables for each example Python script."
+    echo "Run 'source env_paths.sh' to populate the variables in your shell."
+fi


### PR DESCRIPTION
## Summary
- add `env_paths.sh` to export paths for each example script
- document how to source the environment script in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684322551bf8832889fa2fb129db2780